### PR TITLE
fix: corriger pattern artifacts pour inclure tous les modules dans re…

### DIFF
--- a/.github/workflows/build-pdfs.yml
+++ b/.github/workflows/build-pdfs.yml
@@ -188,7 +188,7 @@ jobs:
     - name: 📥 Download all artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: "*-pdf*"
+        pattern: "*pdf*"
         path: ./pdfs
 
     - name: 📋 List downloaded files

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,6 +8,7 @@ on:
       - 'travaux_pratiques/**'
       - 'scripts/**'
       - '.github/workflows/test-build.yml'
+      - '.github/workflows/build-pdfs.yml'
   workflow_dispatch:  # Permet de déclencher manuellement
 
 jobs:


### PR DESCRIPTION
…leases

Le pattern '*-pdf*' excluait l'artifact principal 'formation-linux-pdfs-{SHA}' qui contient tous les modules de base (01-08). Le nouveau pattern '*pdf*' inclut cet artifact principal, garantissant que tous les modules soient disponibles dans les releases GitHub.

Fix: modules 06, 07, 08 manquants dans les releases GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)